### PR TITLE
Add timestamp column

### DIFF
--- a/src/osmium_extension.cpp
+++ b/src/osmium_extension.cpp
@@ -44,6 +44,7 @@ struct OsmRow {
 	OsmKind kind;
 	OsmType type;
 	int64_t id;
+	int64_t timestamp_seconds = 0; // 0 = no/invalid metadata -> SQL NULL
 	std::vector<std::pair<std::string, std::string>> tags;
 	std::string geometry; // WKB encoded
 	std::vector<int64_t> refs;
@@ -85,7 +86,8 @@ static constexpr idx_t COL_GEOMETRY = 4;
 static constexpr idx_t COL_REFS = 5;
 static constexpr idx_t COL_REF_ROLES = 6;
 static constexpr idx_t COL_REF_TYPES = 7;
-static constexpr idx_t NUM_COLUMNS = 8;
+static constexpr idx_t COL_TIMESTAMP = 8;
+static constexpr idx_t NUM_COLUMNS = 9;
 
 // Check whether an element's tags satisfy a single (non-conjunctive) predicate
 static bool MatchesTagPredicate(const osmium::TagList &tags, const TagPredicate &pred) {
@@ -312,6 +314,7 @@ struct OsmGlobalState : public duckdb::GlobalTableFunctionState {
 	int col_out[NUM_COLUMNS];
 	bool needs_geometry = false;
 	bool needs_tags = false;
+	bool needs_timestamp = false;
 
 	OsmGlobalState() {
 		for (idx_t i = 0; i < NUM_COLUMNS; i++) {
@@ -349,6 +352,15 @@ static std::vector<std::pair<std::string, std::string>> ExtractTags(const osmium
 	return result;
 }
 
+// Record an element's last-edited time (UTC seconds since the epoch). OSM files
+// can omit metadata; an invalid timestamp is left as 0 and surfaced as SQL NULL.
+static void SetTimestamp(OsmRow &row, const osmium::OSMObject &object) {
+	const auto ts = object.timestamp();
+	if (ts.valid()) {
+		row.timestamp_seconds = ts.seconds_since_epoch();
+	}
+}
+
 // Process one osmium buffer: iterate matching elements and append rows
 // to state.current_batch. If the MP manager is active, also feeds ways
 // to the assembler (which may produce multipolygon area rows via callback).
@@ -380,6 +392,9 @@ static void ProcessBuffer(OsmGlobalState &state, osmium::memory::Buffer &buffer)
 				row.kind = KIND_AREA;
 				row.type = TYPE_RELATION;
 				row.id = area.orig_id();
+				if (state.needs_timestamp) {
+					SetTimestamp(row, area);
+				}
 				if (state.needs_tags) {
 					row.tags = ExtractTags(area.tags());
 				}
@@ -410,6 +425,9 @@ static void ProcessBuffer(OsmGlobalState &state, osmium::memory::Buffer &buffer)
 			row.kind = KIND_NODE;
 			row.type = TYPE_NODE;
 			row.id = node.id();
+			if (state.needs_timestamp) {
+				SetTimestamp(row, node);
+			}
 			if (state.needs_tags) {
 				row.tags = ExtractTags(node.tags());
 			}
@@ -461,6 +479,9 @@ static void ProcessBuffer(OsmGlobalState &state, osmium::memory::Buffer &buffer)
 				row.kind = KIND_LINE;
 				row.type = TYPE_WAY;
 				row.id = way.id();
+				if (state.needs_timestamp) {
+					SetTimestamp(row, way);
+				}
 				if (state.needs_tags) {
 					row.tags = ExtractTags(way.tags());
 				}
@@ -481,6 +502,9 @@ static void ProcessBuffer(OsmGlobalState &state, osmium::memory::Buffer &buffer)
 				row.kind = KIND_AREA;
 				row.type = TYPE_WAY;
 				row.id = way.id();
+				if (state.needs_timestamp) {
+					SetTimestamp(row, way);
+				}
 				if (state.needs_tags) {
 					row.tags = ExtractTags(way.tags());
 				}
@@ -523,6 +547,9 @@ static void ProcessBuffer(OsmGlobalState &state, osmium::memory::Buffer &buffer)
 				row.kind = KIND_AREA;
 				row.type = TYPE_RELATION;
 				row.id = relation.id();
+				if (state.needs_timestamp) {
+					SetTimestamp(row, relation);
+				}
 				if (state.needs_tags) {
 					row.tags = ExtractTags(relation.tags());
 				}
@@ -541,6 +568,9 @@ static void ProcessBuffer(OsmGlobalState &state, osmium::memory::Buffer &buffer)
 			row.kind = KIND_RELATION;
 			row.type = TYPE_RELATION;
 			row.id = relation.id();
+			if (state.needs_timestamp) {
+				SetTimestamp(row, relation);
+			}
 			if (state.needs_tags) {
 				row.tags = ExtractTags(relation.tags());
 			}
@@ -599,6 +629,9 @@ static duckdb::unique_ptr<duckdb::FunctionData> OsmBind(duckdb::ClientContext &c
 
 	names.emplace_back("ref_types");
 	return_types.emplace_back(duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR));
+
+	names.emplace_back("timestamp");
+	return_types.emplace_back(duckdb::LogicalType::TIMESTAMP_TZ);
 
 	return bind_data;
 }
@@ -970,6 +1003,7 @@ static duckdb::unique_ptr<duckdb::GlobalTableFunctionState> OsmInitGlobal(duckdb
 	}
 	state->needs_geometry = state->col_out[COL_GEOMETRY] >= 0;
 	state->needs_tags = state->col_out[COL_TAGS] >= 0;
+	state->needs_timestamp = state->col_out[COL_TIMESTAMP] >= 0;
 
 	// Build or retrieve cached node location index if needed.
 	bool needs_node_index = state->needs_geometry && bind_data.kind_filter.NeedsNodeIndex();
@@ -1036,6 +1070,7 @@ static void OsmScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &
 	int refs_out = state.col_out[COL_REFS];
 	int roles_out = state.col_out[COL_REF_ROLES];
 	int types_out = state.col_out[COL_REF_TYPES];
+	int ts_out = state.col_out[COL_TIMESTAMP];
 
 	idx_t tags_offset = 0;
 	idx_t refs_offset = 0;
@@ -1081,6 +1116,16 @@ static void OsmScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &
 
 			if (id_out >= 0) {
 				duckdb::FlatVector::GetData<int64_t>(output.data[id_out])[count] = row.id;
+			}
+
+			if (ts_out >= 0) {
+				auto &vec = output.data[ts_out];
+				if (row.timestamp_seconds == 0) {
+					duckdb::FlatVector::SetNull(vec, count, true);
+				} else {
+					duckdb::FlatVector::GetData<duckdb::timestamp_t>(vec)[count] =
+					    duckdb::timestamp_t(row.timestamp_seconds * 1000000LL);
+				}
 			}
 
 			if (tags_out >= 0) {

--- a/test/sql/timestamp.test
+++ b/test/sql/timestamp.test
@@ -1,0 +1,60 @@
+# name: test/sql/timestamp.test
+# description: the timestamp column exposes each element's last-edited time (UTC)
+# group: [sql]
+
+require osmium
+
+# The column is a UTC instant. Comparing against a TIMESTAMPTZ literal is
+# timezone-independent, so these assertions hold regardless of session TimeZone.
+
+# Type is TIMESTAMP WITH TIME ZONE
+query T
+SELECT DISTINCT typeof(timestamp) FROM osmium_read('test/data/bainbridge.osm');
+----
+TIMESTAMP WITH TIME ZONE
+
+# Node
+query I
+SELECT timestamp = TIMESTAMPTZ '2025-04-17 22:52:40+00'
+FROM osmium_read('test/data/bainbridge.osm') WHERE kind = 'node' AND id = 609981906;
+----
+true
+
+# Way emitted as a line
+query I
+SELECT timestamp = TIMESTAMPTZ '2022-09-08 08:26:46+00'
+FROM osmium_read('test/data/bainbridge.osm') WHERE kind = 'line' AND id = 5913873;
+----
+true
+
+# Relation
+query I
+SELECT timestamp = TIMESTAMPTZ '2026-01-31 06:44:42+00'
+FROM osmium_read('test/data/bainbridge.osm') WHERE kind = 'relation' AND id = 1626887;
+----
+true
+
+# Elements without metadata yield NULL. Way 1456812001 (a closed area=yes
+# pedestrian way) has no timestamp attribute in the fixture.
+query I
+SELECT timestamp IS NULL
+FROM osmium_read('test/data/bainbridge.osm') WHERE kind = 'area' AND type = 'way' AND id = 1456812001;
+----
+true
+
+# Projecting only the timestamp column works (projection pushdown path).
+query I
+SELECT count(*) FROM (
+  SELECT timestamp FROM osmium_read('test/data/bainbridge.osm') WHERE kind = 'node'
+);
+----
+317
+
+# timestamp can be selected alongside other columns and ordered. (Compared
+# against a literal rather than displayed, so the result is TimeZone-independent.)
+query II
+SELECT id, timestamp = TIMESTAMPTZ '2025-04-17 22:52:40+00'
+FROM osmium_read('test/data/bainbridge.osm')
+WHERE kind = 'node' AND tags['name'] IS NOT NULL ORDER BY id LIMIT 1;
+----
+609981906	true


### PR DESCRIPTION
This pull request resolves Issue #5 by exposing the `timestamp` metadata to duckdb-osmium queries.

## New `timestamp` column

- The `timestamp` column pulls from osmium's `Timestamp` [class](https://docs.osmcode.org/libosmium/latest/classosmium_1_1Timestamp.html)
- It is exposed as duckdb's `TIMESTAMP WITH TIME ZONE` (`TIMESTAMPTZ`) [data type](https://duckdb.org/docs/lts/sql/data_types/timestamp), with all times set to UTC to avoid time zone confusion.
- `timestamp` is populated at all five emit sites (node, way -> area, etc) using a `SetTimestamp` helper. That helper is gated by a `needs_timestamp` check, so queries not calling the timestamp pay nothing
- An invalid or missing timestamp yields `NULL`

Downstream effect: duckdb-osmium `SELECT * ...` queries will now add `timestamp` as the final (ninth) column.

This PR only exposes the `timestamp` attribute: other metadata columns (`uid`, `changeset`, `version`) are omitted.

## Testing

New tests:

1. Unit tests: under test/sql/timestamp.test, using the test/data/bainbridge.osm data
2. Checked formatting via `clang-format`
3. One-off integration test: I installed my fork of duckdb-osmium and then added `timestamp` as a column to the new `pois` layer in Layercake. This was a test against an osm.pbf file (versus the .osm file in the unit tests)

Results:

1. Unit tests all passed
2. `clang-format` returned with no messages
3. The integration test worked with duckdb v.1.5.3. The new "timestamp" column shows up on the test viewer:

<img width="572" height="462" alt="image" src="https://github.com/user-attachments/assets/c0233394-19a7-4993-9900-b78d90f79c4b" />
